### PR TITLE
[Game] TimedRewardsManager fix #90:

### DIFF
--- a/AAEmu.Game/Core/Managers/AccountManager.cs
+++ b/AAEmu.Game/Core/Managers/AccountManager.cs
@@ -2,11 +2,13 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Models;
 using AAEmu.Game.Models.Account;
+
 using NLog;
 
 namespace AAEmu.Game.Core.Managers;
@@ -183,7 +185,7 @@ public class AccountManager : Singleton<AccountManager>
     }
 
     public bool RemoveCredits(ulong accountId, int credits) => AddCredits(accountId, -credits);
-    
+
     public bool AddLoyalty(ulong accountId, int loyaltyAmount)
     {
         object accLock;

--- a/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
+++ b/AAEmu.Game/Core/Managers/TimedRewardsManager.cs
@@ -44,7 +44,7 @@ public class TimedRewardsManager : Singleton<TimedRewardsManager>
             var newLabor = (short)(currentLabor + addLabor);
             AccountManager.Instance.UpdateLabor(connection.AccountId, newLabor);
 
-            connection.SendPacket(new SCCharacterLaborPowerChangedPacket(addLabor, 0, 0, 0));
+            connection.ActiveChar?.SendPacket(new SCCharacterLaborPowerChangedPacket(addLabor, 0, 0, 0));
 
             // Update cache if character was logged in
             connection.ActiveChar?.InitializeLaborCache(newLabor, DateTime.UtcNow);
@@ -76,7 +76,7 @@ public class TimedRewardsManager : Singleton<TimedRewardsManager>
                 // Update Credits
                 AccountManager.Instance.AddCredits(connection.AccountId, AppConfiguration.Instance.Credits.GetTickAmount(connection.Payment.PremiumState));
                 AccountManager.Instance.UpdateTickTimes(connection.AccountId, DateTime.UtcNow, false, true, false);
-                connection.SendPacket(new SCICSCashPointPacket(AccountManager.Instance.GetAccountDetails(connection.AccountId).Credits));
+                connection.ActiveChar?.SendPacket(new SCICSCashPointPacket(AccountManager.Instance.GetAccountDetails(connection.AccountId).Credits));
             }
 
             // Distribute Loyalty if needed
@@ -85,7 +85,7 @@ public class TimedRewardsManager : Singleton<TimedRewardsManager>
                 // Update Loyalty
                 AccountManager.Instance.AddLoyalty(connection.AccountId, AppConfiguration.Instance.Loyalty.GetTickAmount(connection.Payment.PremiumState));
                 AccountManager.Instance.UpdateTickTimes(connection.AccountId, DateTime.UtcNow, false, false, true);
-                connection.SendPacket(new SCBmPointPacket(AccountManager.Instance.GetAccountDetails(connection.AccountId).Loyalty));
+                connection.ActiveChar?.SendPacket(new SCBmPointPacket(AccountManager.Instance.GetAccountDetails(connection.AccountId).Loyalty));
             }
         }
     }


### PR DESCRIPTION
- when updating the number of work points in offline mode for an account, a packet was sent SCCharacterLaborPowerChangedPacket before the X2EnterWorldResponsePacket, which caused packet numbering to fail;